### PR TITLE
Cập nhật số lượng khi nhập/xuất kho và điều chỉnh cách lưu số lượng sản phẩm

### DIFF
--- a/src/main/java/com/example/web/controller/admin/InventoryController/AddStockIn.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/AddStockIn.java
@@ -86,7 +86,7 @@ public class AddStockIn extends HttpServlet {
             Date date = Date.valueOf(createdDate);
             double totalPrice = products.stream().mapToDouble(StockInItem::getTotalPrice).sum();
 
-            StockIn stockIn = new StockIn(0, creatorId, supplier, note, totalPrice, date);
+            StockIn stockIn = new StockIn(0, creatorId, supplier, note, totalPrice, date, "Chưa áp dụng");
             stockIn.setListPro(products);
 
             int stockInId = stockIOService.saveStockInWithItems(stockIn);

--- a/src/main/java/com/example/web/controller/admin/InventoryController/AddStockOut.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/AddStockOut.java
@@ -88,7 +88,7 @@ public class AddStockOut extends HttpServlet {
             double totalPrice = products.stream().mapToDouble(StockOutItem::getTotalPrice).sum();
             int orderIdParsed = (orderId != null && !orderId.isEmpty()) ? Integer.parseInt(orderId) : 0;
 
-            StockOut stockOut = new StockOut(0, creatorId, reason, orderIdParsed, note, date, totalPrice);
+            StockOut stockOut = new StockOut(0, creatorId, reason, orderIdParsed, note, date, totalPrice, "Chưa áp dụng");
             stockOut.setListPro(products);
 
             int stockOutId = stockIOService.saveStockOutWithItems(stockOut);

--- a/src/main/java/com/example/web/controller/admin/InventoryController/Applied.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/Applied.java
@@ -1,0 +1,61 @@
+package com.example.web.controller.admin.InventoryController;
+
+import com.example.web.service.PaintingService;
+import com.example.web.service.StockIOService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+
+@WebServlet("/admin/inventoryTrans/applied")
+public class Applied extends HttpServlet {
+    private final StockIOService stockIOService = new StockIOService();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String type = req.getParameter("type");
+        String id = req.getParameter("id");
+
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        if (type == null || id == null) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.getWriter().write("{\"error\": \"Thiếu dữ liệu.\"}");
+            return;
+        }
+        try {
+            boolean isApplied;
+            if ("in".equalsIgnoreCase(type)) {
+                isApplied = stockIOService.applyStockInById(id);
+                if (isApplied) {
+                    resp.setStatus(HttpServletResponse.SC_OK);
+                    resp.getWriter().write("{\"success\": \"Phiếu nhập kho đã được áp dụng.\"}");
+                } else {
+                    resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    resp.getWriter().write("{\"error\": \"Không tìm thấy phiếu nhập kho để áp dụng.\"}");
+                }
+            } else if ("out".equalsIgnoreCase(type)) {
+                isApplied = stockIOService.applyStockOutById(id);
+                if (isApplied) {
+                    resp.setStatus(HttpServletResponse.SC_OK);
+                    resp.getWriter().write("{\"success\": \"Phiếu xuất kho đã được áp dụng.\"}");
+                } else {
+                    resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                    resp.getWriter().write("{\"error\": \"Không tìm thấy phiếu xuất kho để áp dụng.\"}");
+                }
+
+            } else {
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.getWriter().write("{\"error\": \"Loại yêu cầu không hợp lệ.\"}");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.getWriter().write("{\"error\": \"Lỗi máy chủ nội bộ.\"}");
+        }
+    }
+}

--- a/src/main/java/com/example/web/controller/admin/InventoryController/Applied.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/Applied.java
@@ -1,5 +1,6 @@
 package com.example.web.controller.admin.InventoryController;
 
+import com.example.web.service.OrderService;
 import com.example.web.service.PaintingService;
 import com.example.web.service.StockIOService;
 import jakarta.servlet.ServletException;
@@ -9,11 +10,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.List;
 
 
 @WebServlet("/admin/inventoryTrans/applied")
 public class Applied extends HttpServlet {
     private final StockIOService stockIOService = new StockIOService();
+    private final OrderService orderService = new OrderService();
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -30,15 +33,38 @@ public class Applied extends HttpServlet {
         try {
             boolean isApplied;
             if ("in".equalsIgnoreCase(type)) {
+                if ("Đã áp dụng".equals(stockIOService.getSIById(Integer.parseInt(id)).getStatus())) {
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    resp.getWriter().write("{\"error\": \"Phiếu nhập kho đã được áp dụng.\"}");
+                    return;
+                }
                 isApplied = stockIOService.applyStockInById(id);
                 if (isApplied) {
                     resp.setStatus(HttpServletResponse.SC_OK);
-                    resp.getWriter().write("{\"success\": \"Phiếu nhập kho đã được áp dụng.\"}");
+                    resp.getWriter().write("{\"success\": \"Phiếu nhập kho đã được áp dụng thành công.\"}");
                 } else {
                     resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
                     resp.getWriter().write("{\"error\": \"Không tìm thấy phiếu nhập kho để áp dụng.\"}");
                 }
             } else if ("out".equalsIgnoreCase(type)) {
+                if ("Đã áp dụng".equals(stockIOService.getSOById(Integer.parseInt(id)).getStatus())) {
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    resp.getWriter().write("{\"error\": \"Phiếu nhập kho đã được áp dụng.\"}");
+                    return;
+                }
+                boolean isDelivery = stockIOService.getSOById(Integer.parseInt(id)).getReason().equals("Giao hàng");
+                if(isDelivery && !orderService.isPendingOrder(stockIOService.getSOById(Integer.parseInt(id)).getOrderId())){
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    resp.getWriter().write("{\"error\": \"Đơn hàng không hợp lệ.\"}");
+                    return;
+                }
+                List<String> insufficientItems = stockIOService.getInsufficientStockItems(id);
+                if (!insufficientItems.isEmpty()) {
+                    resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                    String message = String.join(", ", insufficientItems);
+                    resp.getWriter().write("{\"error\": \"Không đủ tồn kho cho các sản phẩm: " + message + "\"}");
+                    return;
+                }
                 isApplied = stockIOService.applyStockOutById(id);
                 if (isApplied) {
                     resp.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/com/example/web/controller/admin/paintingController/Update.java
+++ b/src/main/java/com/example/web/controller/admin/paintingController/Update.java
@@ -46,7 +46,7 @@ public class Update extends HttpServlet {
 
 
      //   User user = (User) req.getSession().getAttribute("user");
-        if (user == null || hasPermission) {
+        if (user == null || !hasPermission) {
             jsonResponse.addProperty("success", false);
             jsonResponse.addProperty("message", "Bạn không có quyền chỉnh sửa sản phẩm!");
             out.print(new Gson().toJson(jsonResponse));

--- a/src/main/java/com/example/web/dao/OrderDao.java
+++ b/src/main/java/com/example/web/dao/OrderDao.java
@@ -226,4 +226,15 @@ public class OrderDao {
         }
         return false;
     }
+
+    public void updateDeliveryStatus(int id, String status) throws SQLException {
+        String sql = "UPDATE orders SET deliveryStatus = ? WHERE id = ?";
+
+        try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, status);
+            stmt.setInt(2, id);
+
+            stmt.executeUpdate();
+        }
+    }
 }

--- a/src/main/java/com/example/web/dao/StockIODao.java
+++ b/src/main/java/com/example/web/dao/StockIODao.java
@@ -49,13 +49,14 @@ public class StockIODao {
         }
     }
     public int addStockInTrans(StockIn stockIn) throws SQLException{
-        String stockInSql = "INSERT INTO stock_in (createdId, supplier, note, totalPrice, importDate) VALUES (?, ?, ?, ?, ?)";
+        String stockInSql = "INSERT INTO stock_in (createdId, supplier, note, totalPrice, importDate, status) VALUES (?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(stockInSql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setInt(1, stockIn.getCreatedId());
             ps.setString(2, stockIn.getSupplier());
             ps.setString(3, stockIn.getNote());
             ps.setDouble(4, stockIn.getTotalPrice());
             ps.setDate(5, new java.sql.Date(stockIn.getTransactionDate().getTime()));
+            ps.setString(6, stockIn.getStatus());
 
             ps.executeUpdate();
             try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -135,6 +136,7 @@ public class StockIODao {
                 stockIn.setNote(rs.getString("note"));
                 stockIn.setTransactionDate(rs.getDate("importDate"));
                 stockIn.setTotalPrice(rs.getDouble("totalPrice"));
+                stockIn.setStatus(rs.getString("status"));
                 stockIn.setListPro(findItemsByStockInId(id));
             }
         }
@@ -253,8 +255,9 @@ public class StockIODao {
             int orderId = rs.getInt("orderId");
             double totalPrice = rs.getDouble("totalPrice");
             Date transactionDate = rs.getDate("exportDate");
+            String status = rs.getString("status");
 
-            StockOut stockOut = new StockOut(id, createdId, createdName, reason, orderId, note, transactionDate, totalPrice);
+            StockOut stockOut = new StockOut(id, createdId, createdName, reason, orderId, note, transactionDate, totalPrice, status);
             stockOutList.add(stockOut);
         }
         return stockOutList;
@@ -278,6 +281,7 @@ public class StockIODao {
                 stockOut.setNote(rs.getString("note"));
                 stockOut.setTransactionDate(rs.getDate("exportDate"));
                 stockOut.setTotalPrice(rs.getDouble("totalPrice"));
+                stockOut.setStatus(rs.getString("status"));
                 stockOut.setListPro(findItemsByStockOutId(id));
             }
         }
@@ -378,7 +382,7 @@ public class StockIODao {
     }
 
     private int addStockOutTrans(StockOut stockOut) throws SQLException{
-        String stockOutSql = "INSERT INTO stock_out (createdId, reason, orderId, note, totalPrice, exportDate) VALUES (?, ?, ?, ?, ?, ?)";
+        String stockOutSql = "INSERT INTO stock_out (createdId, reason, orderId, note, totalPrice, exportDate, status) VALUES (?, ?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(stockOutSql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setInt(1, stockOut.getCreatedId());
             ps.setString(2, stockOut.getReason());
@@ -390,6 +394,7 @@ public class StockIODao {
             ps.setString(4, stockOut.getNote());
             ps.setDouble(5, stockOut.getTotalPrice());
             ps.setDate(6, new java.sql.Date(stockOut.getTransactionDate().getTime()));
+            ps.setString(7, stockOut.getStatus());
 
             ps.executeUpdate();
             try (ResultSet rs = ps.getGeneratedKeys()) {
@@ -415,13 +420,18 @@ public class StockIODao {
         while (rs.next()) {
             int id = rs.getInt("id");
             int createdId = rs.getInt("createdId");
+            Integer orderId = (Integer) rs.getObject("orderId");
             String createdName = rs.getString("createdName");
             String reason = rs.getString("reason");
             String note = rs.getString("note");
             double totalPrice = rs.getDouble("totalPrice");
             Date transactionDate = rs.getDate("exportDate");
+            String status = rs.getString("status");
+            if (orderId == null) {
+                orderId = -1;
+            }
 
-            stockOut = new StockOut(id, createdId, createdName,  reason, note, transactionDate, totalPrice);
+            stockOut = new StockOut(id, createdId, createdName,  reason, orderId, note, transactionDate, totalPrice, status);
         }
         return stockOut;
     }
@@ -469,8 +479,8 @@ public class StockIODao {
         }
     }
 
-    public void updateStatusSI(int id) {
-        String sql = "UPDATE stock_in SET status = ? WHERE id = ?";
+    public void updateStatus(String table, int id) {
+        String sql = "UPDATE " + table + " SET status = ? WHERE id = ?";
 
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setString(1, "Đã áp dụng");
@@ -480,4 +490,5 @@ public class StockIODao {
             e.printStackTrace();
         }
     }
+
 }

--- a/src/main/java/com/example/web/dao/StockIODao.java
+++ b/src/main/java/com/example/web/dao/StockIODao.java
@@ -84,8 +84,9 @@ public class StockIODao {
             String note = rs.getString("note");
             double totalPrice = rs.getDouble("totalPrice");
             Date transactionDate = rs.getDate("importDate");
+            String status = rs.getString("status");
 
-            StockIn stockIn = new StockIn(id, createdId, createdName,  supplier, note, totalPrice, transactionDate);
+            StockIn stockIn = new StockIn(id, createdId, createdName,  supplier, note, totalPrice, transactionDate, status);
             stockInList.add(stockIn);
         }
         return stockInList;
@@ -141,7 +142,7 @@ public class StockIODao {
         return stockIn;
     }
 
-    private List<StockInItem> findItemsByStockInId(int stockInId) throws SQLException {
+    public List<StockInItem> findItemsByStockInId(int stockInId) throws SQLException {
         List<StockInItem> items = new ArrayList<>();
 
         String sql = "SELECT sii.*, p.title AS productName, s.sizeDescription " +
@@ -230,8 +231,9 @@ public class StockIODao {
             String note = rs.getString("note");
             double totalPrice = rs.getDouble("totalPrice");
             Date transactionDate = rs.getDate("importDate");
+            String status = rs.getString("status");
 
-            stockIn = new StockIn(id, createdId, createdName,  supplier, note, totalPrice, transactionDate);
+            stockIn = new StockIn(id, createdId, createdName,  supplier, note, totalPrice, transactionDate, status);
         }
         return stockIn;
     }
@@ -283,7 +285,7 @@ public class StockIODao {
         return stockOut;
     }
 
-    private List<StockOutItem> findItemsByStockOutId(int id) throws SQLException {
+    public List<StockOutItem> findItemsByStockOutId(int id) throws SQLException {
         List<StockOutItem> items = new ArrayList<>();
 
         String sql = "SELECT soi.*, p.title AS productName, s.sizeDescription " +
@@ -464,6 +466,18 @@ public class StockIODao {
             } catch (SQLException e) {
                 e.printStackTrace();
             }
+        }
+    }
+
+    public void updateStatusSI(int id) {
+        String sql = "UPDATE stock_in SET status = ? WHERE id = ?";
+
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, "Đã áp dụng");
+            ps.setInt(2, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/com/example/web/dao/model/PaintingSize.java
+++ b/src/main/java/com/example/web/dao/model/PaintingSize.java
@@ -5,18 +5,11 @@ import java.io.Serializable;
 public class PaintingSize  implements Serializable {
     private int idSize;
     private String sizeDescriptions;
-    private int quantity;
     private int totalQuantity;
     private int reservedQuantity;
     private Integer displayQuantity;
     private Double weight;
 
-//    public PaintingSize(int idSize,String sizeDescriptions, int quantity, Double weight) {
-//        this.idSize = idSize;
-//        this.sizeDescriptions = sizeDescriptions;
-//        this.quantity = quantity;
-//        this.weight = weight;
-//    }
 
     public PaintingSize(int idSize, String sizeDescriptions, int displayQuantity, Double weight) {
         this.idSize = idSize;
@@ -65,14 +58,6 @@ public class PaintingSize  implements Serializable {
         this.sizeDescriptions = sizeDescriptions;
     }
 
-    public int getQuantity() {
-        return quantity;
-    }
-
-    public void setQuantity(int quantity) {
-        this.quantity = quantity;
-    }
-
     public int getTotalQuantity() {
         return totalQuantity;
     }
@@ -102,7 +87,7 @@ public class PaintingSize  implements Serializable {
         return "PaintingSize{" +
                 "idSize=" + idSize +
                 ", sizeDescriptions='" + sizeDescriptions + '\'' +
-                ", quantity=" + quantity +
+                ", quantity=" + displayQuantity +
                 ", weight=" + weight +
                 '}';
     }

--- a/src/main/java/com/example/web/dao/model/StockIn.java
+++ b/src/main/java/com/example/web/dao/model/StockIn.java
@@ -13,16 +13,18 @@ public class StockIn {
     private Date transactionDate;
     private double totalPrice;
     private List<StockInItem> listPro = new ArrayList<>();
+    private String status;
 
-    public StockIn(int id, int createdId, String supplier, String note, double totalPrice, Date transactionDate) {
+    public StockIn(int id, int createdId, String supplier, String note, double totalPrice, Date transactionDate, String status) {
         this.id = id;
         this.createdId = createdId;
         this.supplier = supplier;
         this.note = note;
         this.totalPrice = totalPrice;
         this.transactionDate = transactionDate;
+        this.status = status;
     }
-    public StockIn(int id, int createdId, String createdName, String supplier, String note, double totalPrice, Date transactionDate) {
+    public StockIn(int id, int createdId, String createdName, String supplier, String note, double totalPrice, Date transactionDate, String status) {
         this.id = id;
         this.createdId = createdId;
         this.createdName = createdName;
@@ -30,6 +32,7 @@ public class StockIn {
         this.note = note;
         this.totalPrice = totalPrice;
         this.transactionDate = transactionDate;
+        this.status = status;
     }
     public StockIn() {
     }
@@ -96,5 +99,13 @@ public class StockIn {
 
     public void setCreatedName(String createdName) {
         this.createdName = createdName;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/web/dao/model/StockOut.java
+++ b/src/main/java/com/example/web/dao/model/StockOut.java
@@ -13,9 +13,10 @@ public class StockOut {
     private String note;
     private Date transactionDate;
     private double totalPrice;
+    private String status;
     private List<StockOutItem> listPro = new ArrayList<>();
 
-    public StockOut(int id, int createdId, String reason, Integer orderId, String note, Date transactionDate, double totalPrice) {
+    public StockOut(int id, int createdId, String reason, Integer orderId, String note, Date transactionDate, double totalPrice, String status) {
         this.id = id;
         this.createdId = createdId;
         this.reason = reason;
@@ -23,9 +24,10 @@ public class StockOut {
         this.note = note;
         this.transactionDate = transactionDate;
         this.totalPrice = totalPrice;
+        this.status = status;
     }
 
-    public StockOut(int id, int createdId, String createdName, String reason, String note, Date transactionDate, double totalPrice) {
+    public StockOut(int id, int createdId, String createdName, String reason, String note, Date transactionDate, double totalPrice, String status) {
         this.id = id;
         this.createdId = createdId;
         this.createdName = createdName;
@@ -33,9 +35,10 @@ public class StockOut {
         this.note = note;
         this.transactionDate = transactionDate;
         this.totalPrice = totalPrice;
+        this.status = status;
     }
 
-    public StockOut(int id, int createdId, String createdName, String reason, Integer orderId, String note, Date transactionDate, double totalPrice) {
+    public StockOut(int id, int createdId, String createdName, String reason, Integer orderId, String note, Date transactionDate, double totalPrice, String status) {
         this.id = id;
         this.createdId = createdId;
         this.createdName = createdName;
@@ -44,6 +47,7 @@ public class StockOut {
         this.note = note;
         this.transactionDate = transactionDate;
         this.totalPrice = totalPrice;
+        this.status = status;
     }
 
     public StockOut() {
@@ -119,5 +123,13 @@ public class StockOut {
 
     public void setListPro(List<StockOutItem> listPro) {
         this.listPro = listPro;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/example/web/service/CheckoutService.java
+++ b/src/main/java/com/example/web/service/CheckoutService.java
@@ -145,7 +145,7 @@ public class CheckoutService {
 
         for(PaintingSize ps : painting.getSizes()){
 
-            if(sizeId == ps.getIdSize() && ps.getQuantity() >= quantity){
+            if(sizeId == ps.getIdSize() && ps.getDisplayQuantity() >= quantity){
                 return true;
             }
         }

--- a/src/main/java/com/example/web/service/OrderService.java
+++ b/src/main/java/com/example/web/service/OrderService.java
@@ -1,13 +1,19 @@
 package com.example.web.service;
 
 import com.example.web.dao.OrderDao;
+import com.example.web.dao.OrderItemDao;
+import com.example.web.dao.PaintingDao;
 import com.example.web.dao.model.Order;
+import com.example.web.dao.model.OrderItem;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class OrderService {
     private OrderDao orderDao = new OrderDao();
+    private PaintingDao paintingDao = new PaintingDao();
+    private OrderItemDao orderItemDao = new OrderItemDao();
 
     public List<Order> getCurrentOrdersForUser(int userId) throws Exception {
         return orderDao.getCurrentOrdersForUser(userId);
@@ -26,7 +32,16 @@ public class OrderService {
         return orderDao.getListAllOrdersHistoryAdmin();
     }
     public boolean updateOrderStatus(int orderId, String status, String recipientName, String recipientPhone, String deliveryAddress) throws Exception {
-        return orderDao.updateOrderStatus(orderId, status,recipientName,recipientPhone, deliveryAddress);
+        boolean success = false;
+        List<OrderItem> orderItems = new ArrayList<>();
+
+        if ("đã hủy giao hàng".equalsIgnoreCase(status)) {
+            orderItems = orderItemDao.getListOrderItem(orderId);
+            paintingDao.returnQuantity(orderItems);
+        }
+        success = orderDao.updateOrderStatus(orderId, status, recipientName, recipientPhone, deliveryAddress);
+
+        return success;
     }
 
     public boolean updatePaymentStatus(int orderId, String paymentStatus) {

--- a/src/main/java/com/example/web/service/OrderService.java
+++ b/src/main/java/com/example/web/service/OrderService.java
@@ -64,4 +64,8 @@ public class OrderService {
     public boolean isPendingOrder(int id) throws SQLException {
         return orderDao.isPendingOrder(id);
     }
+
+    public void updateDeliveryStatus(int id, String status) throws SQLException {
+        orderDao.updateDeliveryStatus(id, status);
+    }
 }

--- a/src/main/java/com/example/web/service/PaintingService.java
+++ b/src/main/java/com/example/web/service/PaintingService.java
@@ -3,6 +3,7 @@ package com.example.web.service;
 import com.example.web.dao.PaintingDao;
 import com.example.web.dao.model.*;
 
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,7 +94,11 @@ public class PaintingService {
         return paintingDao.applySI(items);
     }
 
-    public boolean applySO(List<StockOutItem> items) throws SQLException {
-        return paintingDao.applySO(items);
+    public boolean applySO(List<StockOutItem> items, boolean isDelivery) throws SQLException {
+        return paintingDao.applySO(items, isDelivery);
+    }
+
+    public int getQuantity(int productId, int sizeId) {
+        return paintingDao.getQuantity(productId, sizeId);
     }
 }

--- a/src/main/java/com/example/web/service/PaintingService.java
+++ b/src/main/java/com/example/web/service/PaintingService.java
@@ -1,9 +1,7 @@
 package com.example.web.service;
 
 import com.example.web.dao.PaintingDao;
-import com.example.web.dao.model.Order;
-import com.example.web.dao.model.OrderItem;
-import com.example.web.dao.model.Painting;
+import com.example.web.dao.model.*;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -91,6 +89,11 @@ public class PaintingService {
 
 
     }
+    public boolean applySI(List<StockInItem> items) throws SQLException {
+        return paintingDao.applySI(items);
+    }
 
-
+    public boolean applySO(List<StockOutItem> items) throws SQLException {
+        return paintingDao.applySO(items);
+    }
 }

--- a/src/main/java/com/example/web/service/StockIOService.java
+++ b/src/main/java/com/example/web/service/StockIOService.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class StockIOService {
     private final StockIODao stockIODao = new StockIODao();
     private final PaintingService paintingService = new PaintingService();
+    private final OrderService orderService = new OrderService();
     public List<StockIn> getAll() throws SQLException {
         return stockIODao.getAll();
     }
@@ -54,8 +55,13 @@ public class StockIOService {
 
     public boolean applyStockOutById(String id) throws SQLException {
         List<StockOutItem> items = stockIODao.findItemsByStockOutId(Integer.parseInt(id));
-        if(paintingService.applySO(items)){
-            stockIODao.updateStatusSI(Integer.parseInt(id));
+        boolean isDelivery = stockIODao.getSOById(Integer.parseInt(id)).getReason().equals("Giao hàng");
+        if(paintingService.applySO(items, isDelivery)){
+            stockIODao.updateStatus("stock_out", Integer.parseInt(id));
+            if(isDelivery){
+                int orderId = stockIODao.getSOById(Integer.parseInt(id)).getOrderId();
+                orderService.updateDeliveryStatus(orderId,"đang giao");
+            }
             return true;
         }
         return false;
@@ -63,9 +69,25 @@ public class StockIOService {
     public boolean applyStockInById(String id) throws SQLException {
         List<StockInItem> items = stockIODao.findItemsByStockInId(Integer.parseInt(id));
         if(paintingService.applySI(items)){
-            stockIODao.updateStatusSI(Integer.parseInt(id));
+            stockIODao.updateStatus("stock_in", Integer.parseInt(id));
             return true;
         }
         return false;
+    }
+
+    public List<String> getInsufficientStockItems(String id) throws SQLException {
+        List<StockOutItem> items = stockIODao.findItemsByStockOutId(Integer.parseInt(id));
+        List<String> insufficientItems = new ArrayList<>();
+
+        for (StockOutItem item : items) {
+            int currentStock = paintingService.getQuantity(item.getProductId(), item.getSizeId());
+            if (currentStock < item.getQuantity()) {
+                String productName = paintingService.getPainting(item.getProductId()).getTitle();
+                insufficientItems.add(String.format("%s (Size: %s, Tồn: %d, Cần: %d)",
+                        productName, item.getSizeId(), currentStock, item.getQuantity()));
+            }
+        }
+
+        return insufficientItems;
     }
 }

--- a/src/main/java/com/example/web/service/StockIOService.java
+++ b/src/main/java/com/example/web/service/StockIOService.java
@@ -4,12 +4,15 @@ import com.example.web.dao.StockIODao;
 import com.example.web.dao.model.StockIn;
 import com.example.web.dao.model.StockInItem;
 import com.example.web.dao.model.StockOut;
+import com.example.web.dao.model.StockOutItem;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class StockIOService {
     private final StockIODao stockIODao = new StockIODao();
+    private final PaintingService paintingService = new PaintingService();
     public List<StockIn> getAll() throws SQLException {
         return stockIODao.getAll();
     }
@@ -47,5 +50,22 @@ public class StockIOService {
 
     public boolean deleteStockOutById(String id) {
         return stockIODao.deleteStockOutById(Integer.parseInt(id));
+    }
+
+    public boolean applyStockOutById(String id) throws SQLException {
+        List<StockOutItem> items = stockIODao.findItemsByStockOutId(Integer.parseInt(id));
+        if(paintingService.applySO(items)){
+            stockIODao.updateStatusSI(Integer.parseInt(id));
+            return true;
+        }
+        return false;
+    }
+    public boolean applyStockInById(String id) throws SQLException {
+        List<StockInItem> items = stockIODao.findItemsByStockInId(Integer.parseInt(id));
+        if(paintingService.applySI(items)){
+            stockIODao.updateStatusSI(Integer.parseInt(id));
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/webapp/admin/products.jsp
+++ b/src/main/webapp/admin/products.jsp
@@ -447,8 +447,8 @@
               <div class="row fw-bold border-bottom pb-2 mb-2 text-center">
                 <div class="col-md-3" style="font-size: 0.85rem;">Kích thước</div>
                 <div class="col-md-2" style="font-size: 0.85rem;">Tổng</div>
-                <div class="col-md-2" style="font-size: 0.85rem;">Đặt</div>
-                <div class="col-md-3" style="font-size: 0.85rem;">Bán</div>
+                <div class="col-md-2" style="font-size: 0.85rem;">Đã Đặt</div>
+                <div class="col-md-3" style="font-size: 0.85rem;">Có Sẵn</div>
               </div>
               <c:forEach var="size" items="${sizes}">
                 <div class="size-quantity-pair">

--- a/src/main/webapp/admin/stockIO.jsp
+++ b/src/main/webapp/admin/stockIO.jsp
@@ -174,6 +174,7 @@
         </div>
         <div class="modal-footer">
           <strong class="me-auto"> Tổng tiền: <span id="totalPrice"></span></strong>
+          <button type="button" class="btn btn-success" id="applyBtn">Áp dụng</button>
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
         </div>
       </div>

--- a/src/main/webapp/admin/stockIO.jsp
+++ b/src/main/webapp/admin/stockIO.jsp
@@ -96,7 +96,9 @@
               <td>${si.note}</td>
               <td>
                 <button class="btn btn-sm btn-info viewDetailSIButton" data-stockin-id="${si.id}" data-bs-toggle="modal" data-bs-target="#detailModal">Chi tiết</button>
-                <button class="btn btn-sm btn-danger deleteStockInButton" data-id="${si.id}">Xoá</button>
+                <c:if test="${si.status == 'Chưa áp dụng'}">
+                  <button class="btn btn-sm btn-danger deleteStockInButton" data-id="${si.id}">Xoá</button>
+                </c:if>
               </td>
             </tr>
           </c:forEach>
@@ -131,7 +133,9 @@
                   <td>${so.note}</td>
                   <td>
                     <button class="btn btn-sm btn-info viewDetailSOButton" data-stockout-id="${so.id}" data-bs-toggle="modal" data-bs-target="#detailModalSo">Chi tiết</button>
-                    <button class="btn btn-sm btn-danger deleteStockOButton" data-id="${so.id}">Xoá</button>
+                    <c:if test="${so.status == 'Chưa áp dụng'}">
+                      <button class="btn btn-sm btn-danger deleteStockOButton" data-id="${so.id}">Xoá</button>
+                    </c:if>
                   </td>
                 </tr>
               </c:forEach>
@@ -216,6 +220,7 @@
       </div>
       <div class="modal-footer">
         <strong class="me-auto"> Tổng tiền: <span id="totalPriceSo"></span></strong>
+        <button type="button" class="btn btn-success" id="applySOBtn">Áp dụng</button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
       </div>
     </div>

--- a/src/main/webapp/assets/js/admin/stockIO.js
+++ b/src/main/webapp/assets/js/admin/stockIO.js
@@ -70,6 +70,47 @@ $(document).ready(function() {
             }
         });
     });
+    document.getElementById('applyBtn').addEventListener('click', function() {
+        Swal.fire({
+            title: 'Bạn có chắc chắn muốn áp dụng?',
+            text: "Phiếu nhập kho sẽ được áp dụng và số lượng sẽ được cập nhật!",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Áp dụng',
+            cancelButtonText: 'Hủy'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                var stockInId = $('#siId').text();
+                $.ajax({
+                    url: 'inventoryTrans/applied',
+                    type: 'POST',
+                    data: {
+                        id: stockInId,
+                        type: "in"
+                    },
+                    success: function(response) {
+                        Swal.fire(
+                            'Đã áp dụng!',
+                            'Phiếu nhập kho đã được áp dụng và số lượng được cập nhật.',
+                            'success'
+                        );
+                        console.log('Yêu cầu đã được xử lý thành công');
+                    },
+                    error: function(xhr, status, error) {
+                        Swal.fire(
+                            'Lỗi!',
+                            'Có lỗi xảy ra khi áp dụng phiếu nhập kho. Vui lòng thử lại.',
+                            'error'
+                        );
+                        console.log('Lỗi trong quá trình gửi yêu cầu:', error);
+                    }
+                });
+            } else {
+                console.log('Hủy áp dụng!');
+            }
+        });
+    });
+
     $(document).on('click', '.viewDetailSOButton', function () {
         const stockOutId = $(this).data('stockout-id');
         $.ajax({

--- a/src/main/webapp/assets/js/admin/stockIO.js
+++ b/src/main/webapp/assets/js/admin/stockIO.js
@@ -42,6 +42,11 @@ $(document).ready(function() {
             data: { id: stockInId, type: "in" },
             success: function(response) {
                 console.log(response);
+                if (response.status === 'Chưa áp dụng') {
+                    $('#applyBtn').show();
+                } else {
+                    $('#applyBtn').hide();
+                }
                 $('#siId').text(response.id);
                 $('#importDate').text(response.transactionDate);
                 $('#createBy').text(response.createdName);
@@ -94,15 +99,69 @@ $(document).ready(function() {
                             'Phiếu nhập kho đã được áp dụng và số lượng được cập nhật.',
                             'success'
                         );
-                        console.log('Yêu cầu đã được xử lý thành công');
+                        $(`.deleteStockInButton[data-id="${stockInId}"]`).remove();
                     },
                     error: function(xhr, status, error) {
+                        let errorMessage = 'Có lỗi xảy ra khi áp dụng phiếu. Vui lòng thử lại.';
+                        try {
+                            const response = JSON.parse(xhr.responseText);
+                            if (response.error) {
+                                errorMessage = response.error;
+                            }
+                        } catch (e) {
+                        }
                         Swal.fire(
                             'Lỗi!',
-                            'Có lỗi xảy ra khi áp dụng phiếu nhập kho. Vui lòng thử lại.',
+                            errorMessage,
                             'error'
                         );
-                        console.log('Lỗi trong quá trình gửi yêu cầu:', error);
+                    }
+                });
+            } else {
+                console.log('Hủy áp dụng!');
+            }
+        });
+    });
+    document.getElementById('applySOBtn').addEventListener('click', function() {
+        Swal.fire({
+            title: 'Bạn có chắc chắn muốn áp dụng?',
+            text: "Phiếu xuất kho sẽ được áp dụng và số lượng sẽ được cập nhật!",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Áp dụng',
+            cancelButtonText: 'Hủy'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                var stockOId = $('#soId').text();
+                $.ajax({
+                    url: 'inventoryTrans/applied',
+                    type: 'POST',
+                    data: {
+                        id: stockOId,
+                        type: "out"
+                    },
+                    success: function(response) {
+                        Swal.fire(
+                            'Đã áp dụng!',
+                            'Phiếu xuất kho đã được áp dụng và số lượng được cập nhật.',
+                            'success'
+                        );
+                        $(`.deleteStockOButton[data-id="${stockOId}"]`).remove();
+                    },
+                    error: function(xhr, status, error) {
+                        let errorMessage = 'Có lỗi xảy ra khi áp dụng phiếu. Vui lòng thử lại.';
+                        try {
+                            const response = JSON.parse(xhr.responseText);
+                            if (response.error) {
+                                errorMessage = response.error;
+                            }
+                        } catch (e) {
+                        }
+                        Swal.fire(
+                            'Lỗi!',
+                            errorMessage,
+                            'error'
+                        );
                     }
                 });
             } else {
@@ -119,6 +178,11 @@ $(document).ready(function() {
             data: { id: stockOutId, type: "out" },
             success: function(response) {
                 console.log(response);
+                if (response.status === 'Chưa áp dụng') {
+                    $('#applySOBtn').show();
+                } else {
+                    $('#applySOBtn').hide();
+                }
                 $('#soId').text(response.id);
                 $('#exportDate').text(response.transactionDate);
                 $('#createBySo').text(response.createdName);
@@ -152,7 +216,7 @@ $(document).ready(function() {
     });
 
 
-    $(".deleteStockInButton").click(function() {
+    $(document).on('click', '.deleteStockInButton', function() {
         var stockInId = $(this).data("id");
 
         Swal.fire({
@@ -202,7 +266,7 @@ $(document).ready(function() {
             }
         });
     });
-    $(".deleteStockOButton").click(function() {
+    $(document).on('click', '.deleteStockOButton', function() {
         var stockOutId = $(this).data("id");
 
         Swal.fire({
@@ -347,7 +411,7 @@ function submitStockIn() {
                 response.stockIn.totalPrice.toLocaleString() + ' VND',
                 response.stockIn.note ?? '',
                 '<button class="btn btn-sm btn-info viewDetailSIButton" data-stockin-id="'+ response.stockIn.id +'"  data-bs-toggle="modal" data-bs-target="#detailModal">Chi tiết</button>'+
-                '<button class="btn btn-sm btn-danger">Xoá</button>'
+                '<button class="btn btn-sm btn-danger deleteStockInButton" data-id="'+ response.stockIn.id +'">Xoá</button>'
             ]).draw();
             resetForm();
         },
@@ -476,7 +540,7 @@ function submitStockOut() {
                 response.stockOut.totalPrice.toLocaleString() + ' VND',
                 response.stockOut.note ?? '',
                 '<button class="btn btn-sm btn-info viewDetailSOButton" data-stockout-id="'+ response.stockOut.id +'"  data-bs-toggle="modal" data-bs-target="#detailModalSo">Chi tiết</button>'+
-                '<button class="btn btn-sm btn-danger">Xoá</button>'
+                '<button class="btn btn-sm btn-danger deleteStockOButton" data-id="'+ response.stockOut.id +'">Xoá</button>'
             ]).draw();
             resetFormOut();
         },

--- a/src/main/webapp/assets/js/checkout.js
+++ b/src/main/webapp/assets/js/checkout.js
@@ -115,6 +115,7 @@ document.querySelector("#submitPayment").addEventListener("click", function () {
     `);
             },
             error: function (xhr) {
+                let errorText = xhr.responseText
                 if (xhr.status === 401) {
                     alert("Bạn cần đăng nhập để thực hiện thanh toán!");
                     $("#loginModal").modal("show");
@@ -126,6 +127,7 @@ document.querySelector("#submitPayment").addEventListener("click", function () {
                         alert(msg);
                     }
                 } else {
+                    console.error("Lỗi từ server: " + errorText);
                     alert("Đã xảy ra lỗi trong quá trình thanh toán. Vui lòng thử lại!");
                 }
             }

--- a/src/main/webapp/assets/js/personal.js
+++ b/src/main/webapp/assets/js/personal.js
@@ -84,7 +84,6 @@ $(document).ready(function () {
                     
                     
                 `)}
-                        debugger
                         $('#cancelOrderButton').off('click').on('click', function () {
                             const recipientName = $('#recipientName').val();
                             const recipientPhone = $('#recipientPhone').val();


### PR DESCRIPTION
**Mô tả**
- Thêm các thuộc tính phù hợp cho 1 sản phẩm tương ứng các size khác nhau: tổng số lượng(totalQuantity), số lượng hiển thị(displayQuantity), số lượng được đặt(reservedQuantity).
- Khi đặt hàng: tăng reserved giảm display
- Khi giao hàng(xuất giao hàng): giảm total và reserved
- Xuất kho(không phải giao hàng): giảm total và tính toán lại display
- Hủy đơn: giảm reserved tăng display
- Nhập kho: tăng total ( và display)
- Số lượng hiển thị(displayQuantity) có thể chỉnh sửa và display<= total - reserved

**Xuất/nhập kho**
- Có nút áp dụng khi bấm vào "xem chi tiết" của phiếu.
- Áp dụng rồi thì không thể xóa.

**Kiểm tra khi xuất hàng**
- Phiếu xuất hàng đã được áp dụng chưa
- Nếu là đơn hàng cần kiểm tra trạng thái đơn có là "chờ",  cập nhật lại số lượng sản phẩm (total và reserved).
- Nếu là các lý do khác thì khi áp dụng cần kiểm tra số lượng còn trong kho có đủ đáp ứng yêu cầu không.

**Giải quyết issue:** #64 
Ngày: 05/05/2025