### PR TITLE
Hiển thị danh sách đơn hàng theo mục

### DIFF
--- a/src/main/java/com/example/web/controller/admin/OrderController/UpdateStatusOrder.java
+++ b/src/main/java/com/example/web/controller/admin/OrderController/UpdateStatusOrder.java
@@ -17,7 +17,6 @@ import java.sql.SQLException;
 @WebServlet("/update-order-status")
 public class UpdateStatusOrder extends HttpServlet {
     private final OrderService orderService = new OrderService();
-    private final String permission ="UPDATE_ORDERS";
 
 
     @Override
@@ -27,15 +26,6 @@ public class UpdateStatusOrder extends HttpServlet {
 
         PrintWriter out = response.getWriter();
 
-
-        boolean hasPermission = CheckPermission.checkPermission(user, permission, "ADMIN");
-        if (!hasPermission) {
-          //  response.sendRedirect(request.getContextPath() + "/NoPermission.jsp");
-
-            out.write("{\"message\": \"ban không có quyền\"}");
-
-            return;
-        }
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 

--- a/src/main/java/com/example/web/controller/orderController/GetOrderForUser.java
+++ b/src/main/java/com/example/web/controller/orderController/GetOrderForUser.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,10 +28,13 @@ public class GetOrderForUser extends HttpServlet {
 
         List<Order> currentOrders = null;
         List<Order> previousOrders = null;
+        List<Order> allOrders;
         try {
             currentOrders = orderService.getCurrentOrdersForUser(userId);
             previousOrders = orderService.getHistoryOrder(userId);
-
+            allOrders = new ArrayList<>();
+            allOrders.addAll(currentOrders);
+            allOrders.addAll(previousOrders);
 
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -39,12 +43,10 @@ public class GetOrderForUser extends HttpServlet {
         Map<String, Object> result = new HashMap<>();
         result.put("currentOrders", currentOrders);
         result.put("previousOrders", previousOrders);
+        result.put("orders", allOrders);
 
-        System.out.println(GsonProvider.getGson().toJson(result));
         resp.setContentType("application/json");
         resp.setCharacterEncoding("UTF-8");
         resp.getWriter().write(GsonProvider.getGson().toJson(result));
     }
-
-
 }

--- a/src/main/java/com/example/web/dao/OrderDao.java
+++ b/src/main/java/com/example/web/dao/OrderDao.java
@@ -92,7 +92,25 @@ public class OrderDao {
         return orders;
     }
 
+    // lấy tất cả đơn của user
+    public List<Order> getOrdersForUser(int userId) throws SQLException {
+        List<Order> orders = new ArrayList<>();
+        String sql = "SELECT * FROM orders WHERE userId = ? AND isDelete = 0 ORDER BY orderDate DESC";
 
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Order order = extractOrderFromResultSet(rs);
+                    orders.add(order);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return orders;
+    }
 
     public Order getOrder(int orderId) throws Exception {
         String sql = "SELECT * FROM orders WHERE id = ? AND isDelete = 0 ";

--- a/src/main/java/com/example/web/service/CheckoutService.java
+++ b/src/main/java/com/example/web/service/CheckoutService.java
@@ -19,7 +19,6 @@ public class CheckoutService {
     private final OrderDao orderDao;
     private final OrderItemDao orderItemDao;    private final PaymentDao paymentDao;
     private final PaintingDao paintingDao;
-    private final OrderCacheManager cacheManager = new OrderCacheManager();
 
     public CheckoutService() {
         orderDao = new OrderDao();
@@ -71,8 +70,6 @@ public class CheckoutService {
         payment.setPaymentDate(LocalDateTime.now());
         paymentDao.createPayment(payment);
 
-        cacheManager.invalidateCurrentOrders(userId);
-        cacheManager.invalidateAdminCurrentOrders();
 
     }
 
@@ -123,10 +120,6 @@ public class CheckoutService {
         payment.setPaymentStatus(paymentMethodId == 1 ? "đã thanh toán" : "chờ");
         payment.setPaymentDate(LocalDateTime.now());
         paymentDao.createPayment(payment);
-
-        cacheManager.invalidateCurrentOrders(userId);
-        cacheManager.invalidateAdminCurrentOrders();
-
 
         return orderId;
     }

--- a/src/main/java/com/example/web/service/OrderService.java
+++ b/src/main/java/com/example/web/service/OrderService.java
@@ -42,6 +42,10 @@ public class OrderService {
         cacheManager.putHistoryOrders(userId, orders);
         return orders;
     }
+    public List<Order> getOrdersForUser(int userId) throws Exception {
+        return orderDao.getOrdersForUser(userId);
+    }
+
     public Order getOrder(int orderId) throws Exception {
         return orderDao.getOrder(orderId);
     }
@@ -56,20 +60,19 @@ public class OrderService {
         }
         success = orderDao.updateOrderStatus(orderId, status, recipientName, recipientPhone, deliveryAddress);
 
-        if(success) {
+        if (success) {
             Order order = orderDao.getOrder(orderId);
             if (order != null) {
                 int userId = order.getUserId();
 
                 cacheManager.invalidateCurrentOrders(userId);
                 cacheManager.invalidateHistoryOrders(userId);
-
-                List<Order> newOrders = orderDao.getCurrentOrdersForUser(userId);
-                cacheManager.putCurrentOrders(userId, newOrders);
             }
+
             cacheManager.invalidateAdminCurrentOrders();
             cacheManager.invalidateAdminHistoryOrders();
         }
+
         return success;
     }
 

--- a/src/main/webapp/admin/orders.jsp
+++ b/src/main/webapp/admin/orders.jsp
@@ -83,7 +83,7 @@
           <td>${order.orderDate}</td>
           <td>${order.paymentStatus}</td>
           <td>${order.paymentMethod}</td>
-          <td id="delivery-status-${order.id}">${order.deliveryStatus}</td>
+          <td class="delivery-status" data-order-id="${order.id}">${order.deliveryStatus}</td>
           <td><button class="btn btn-info btn-sm" data-bs-toggle="modal"
                       data-bs-target="#orderDetailsModal"
                       data-order-id="${order.id}">Xem Chi Tiết</button>

--- a/src/main/webapp/assets/js/admin/order.js
+++ b/src/main/webapp/assets/js/admin/order.js
@@ -120,30 +120,29 @@ $(document).ready(function () {
             }
 
         });
-        updateStatusBtn.on('click', function () {
-            const newStatus = statusSelect.val();
+        $('#updateStatusBtn').off('click').on('click', function () {
+            const newStatus = $('#statusSelect').val();
             const recipientName = $('#recipientName').val();
             const recipientPhone = $('#recipientPhone').val();
             const deliveryAddress = $('#deliveryAddress').val();
 
             $.ajax({
-                url: `../update-order-status`,
+                url: '../update-order-status',
                 method: 'POST',
                 data: {
-
                     orderId: orderId,
                     deliveryStatus: newStatus,
-                    recipientName : recipientName,
+                    recipientName: recipientName,
                     deliveryAddress: deliveryAddress,
-                    recipientPhone :recipientPhone
+                    recipientPhone: recipientPhone
                 },
-                success: function (response) {
-                    alert('Cập nhật trạng thái thành công');
-                    deliveryStatus.text(newStatus);
-                    // Cập nhật status trong bảng (ngoài modal)
-                    $(`#delivery-status-${orderId}`).text(newStatus);
-                    $('#orderDetailsModal').modal('hide');
+                success: function () {
+                    $('#orderStatus').text(newStatus);
 
+                    $(`.delivery-status[data-order-id='${orderId}']`).text(newStatus);
+
+                    const modal = bootstrap.Modal.getInstance(document.getElementById('orderDetailsModal'));
+                    modal.hide();
                 },
                 error: function () {
                     alert('Lỗi khi cập nhật trạng thái đơn hàng');

--- a/src/main/webapp/user/personal.jsp
+++ b/src/main/webapp/user/personal.jsp
@@ -201,13 +201,25 @@
     <p>Không tìm thấy thông tin người dùng.</p>
 </c:if>
 
-<!-- Bảng Đơn Hàng Hiện Tại -->
+<!-- Danh sách đơn hàng -->
 <div class="card mb-4" style="margin: 30px">
-    <div class="card-header bg-success text-white" style="background: #e7621b !important;">
-        <h4>Đơn Hàng Hiện Tại</h4>
+    <div class="card-header text-white" style="background: #e7621b !important;">
+        <h4>Đơn Hàng Của Bạn</h4>
     </div>
     <div class="card-body">
-        <table id="currentOrders" class="table table-bordered display">
+
+        <!-- Tabs lọc theo trạng thái -->
+        <div class="order-status-tabs d-flex justify-content-start mb-4" id="orderStatusTabs">
+            <button class="status-tab active" data-status="ALL">Tất cả</button>
+            <button class="status-tab" data-status="chờ">Chờ xác nhận</button>
+            <button class="status-tab" data-status="đang giao">Vận chuyển</button>
+            <button class="status-tab" data-status="hoàn thành">Hoàn thành</button>
+            <button class="status-tab" data-status="đã hủy giao hàng">Đã hủy</button>
+            <button class="status-tab" data-status="giao hàng thất bại">Thất bại</button>
+        </div>
+
+        <!-- Bảng đơn hàng gộp -->
+        <table id="allOrders" class="table table-bordered display">
             <thead>
             <tr>
                 <th>Mã Đơn Hàng</th>
@@ -224,29 +236,6 @@
     </div>
 </div>
 
-<!-- Bảng lịch sử đơn hàng -->
-<div class="card mb-4" style="margin: 30px">
-    <div class="card-header bg-secondary text-white">
-        <h4>Lịch Sử Đơn Hàng</h4>
-    </div>
-    <div class="card-body">
-        <table id="orderHistory" class="table table-bordered display">
-            <thead>
-            <tr>
-                <th>Mã Đơn Hàng</th>
-                <th>Tổng Tiền</th>
-                <th>Ngày Đặt</th>
-                <th>Ngày Giao</th>
-                <th>Thanh Toán</th>
-                <th>Phương thức TT</th>
-                <th>Vận chuyển</th>
-                <th>Hành Động</th>
-            </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-</div>
 
 <div class="modal fade" id="orderDetailsModal" tabindex="-1" aria-labelledby="orderDetailsModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
@@ -457,6 +446,33 @@
         });
     });
 </script>
+<style>
+    .order-status-tabs {
+        border-bottom: 1px solid #eee;
+        overflow-x: auto;
+    }
+
+    .status-tab {
+        background: none;
+        border: none;
+        padding: 12px 18px;
+        font-weight: 500;
+        font-size: 16px;
+        color: #555;
+        border-bottom: 2px solid transparent;
+        transition: all 0.2s ease-in-out;
+    }
+
+    .status-tab:hover {
+        color: #ee4d2d;
+    }
+
+    .status-tab.active {
+        color: #ee4d2d;
+        border-bottom: 2px solid #ee4d2d;
+        font-weight: 600;
+    }
+</style>
 
 <script src="${pageContext.request.contextPath}/assets/js/personal.js"></script>
 <script src="${pageContext.request.contextPath}/assets/js/header.js"></script>


### PR DESCRIPTION
**Mô tả:**
Giao diện cũ sử dụng hai bảng riêng biệt để hiển thị đơn hàng hiện tại và lịch sử đơn hàng, gây khó theo dõi khi số lượng đơn hàng nhiều. PR này refactor giao diện thành dạng tabs lọc theo trạng thái.

**Tóm tắt thay đổi:**
Refactor giao diện personal.jsp sang tab filter thay vì hiển thị 2 bảng.
Gộp currentOrders và previousOrders thành orders trong backend.
Cập nhật JS để lọc, hiển thị đơn hàng theo từng trạng thái:
tất cả, chờ, đang giao, hoàn thành, đã hủy, thất bại.
Hủy đơn hàng trực tiếp từ modal (cập nhật trạng thái và ẩn đơn khỏi tab cũ).
Cập nhật deliveryStatus trực tiếp ở bảng admin mà không reload.
Fix logic cache invalidation khi trạng thái đơn hàng thay đổi.
**Chi tiết kỹ thuật:**
frontend:
Thêm HTML các tab trạng thái trong personal.jsp
Chỉ giữ 1 bảng duy nhất #allOrders
Modal xem chi tiết hiển thị thông tin đơn và hỗ trợ hủy đơn
Cập nhật lại JS để load orders, lọc theo tab, thao tác DOM thay vì reload
backend:
Cập nhật servlet /user/orders trả về thêm orders = current + history
Fix hàm updateOrderStatus() trong OrderService để invalidate cả currentOrders và historyOrders đúng lúc
Thêm invalidateOrders(userId) trong OrderCacheManager để tiện xử lý chung

**Giải quyết:**
Issue: https://github.com/haodo04/TTLTW/issues/112